### PR TITLE
Adjusting package options

### DIFF
--- a/codetoolbarexplorer.lpk
+++ b/codetoolbarexplorer.lpk
@@ -2,7 +2,7 @@
 <CONFIG>
   <Package Version="5">
     <PathDelim Value="\"/>
-    <Name Value="codetoolbarexplorer"/>
+    <Name Value="CodeToolbarExplorer"/>
     <Type Value="RunAndDesignTime"/>
     <Author Value="Anderson Fiori"/>
     <CompilerOptions>

--- a/codetoolbarexplorer.lpk
+++ b/codetoolbarexplorer.lpk
@@ -3,7 +3,7 @@
   <Package Version="5">
     <PathDelim Value="\"/>
     <Name Value="CodeToolbarExplorer"/>
-    <Type Value="RunAndDesignTime"/>
+    <Type Value="DesignTime"/>
     <Author Value="Anderson Fiori"/>
     <CompilerOptions>
       <Version Value="11"/>

--- a/codetoolbarexplorer.lpk
+++ b/codetoolbarexplorer.lpk
@@ -11,6 +11,9 @@
       <SearchPaths>
         <UnitOutputDirectory Value="lib\$(TargetCPU)-$(TargetOS)"/>
       </SearchPaths>
+      <Other>
+        <CustomOptions Value="$(IDEBuildOptions)"/>
+      </Other>
     </CompilerOptions>
     <License Value="MIT License"/>
     <Files>


### PR DESCRIPTION
This package is designed-only, and should not be used in projects ([wiki](https://wiki.freepascal.org/Lazarus_Packages#Design_Time_vs_Run_Time_package)).

The `$(IDEBuildOptions)` macro is intended to ensure that the package is compiled with the same options as the IDE itself. For example, in the case of a debug version, the package will also be debuggable.